### PR TITLE
Remove redundant API key check

### DIFF
--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "0.12.2"
+  spec.add_dependency "faraday", "0.10.0"
   spec.add_dependency "faraday_middleware", "~> 0.10"
 
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "faraday", "0.12.0"
+  spec.add_runtime_dependency "faraday", "0.12.0.1"
   spec.add_runtime_dependency "faraday_middleware", "~> 0.12"
 
   spec.add_development_dependency "bundler", "~> 1.16"

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -1,6 +1,5 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "faceit-ruby/client"
 
 
 Gem::Specification.new do |spec|

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "faraday", "0.10.0"
-  spec.add_dependency "faraday_middleware", "~> 0.10"
+  spec.add_runtime_dependency "faraday", "0.12.0"
+  spec.add_runtime_dependency "faraday_middleware", "~> 0.12"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "faceit-ruby"
-  spec.version       = "3.0.7"
+  spec.version       = "3.0.8"
   spec.authors       = ["Kalle Lundgren"]
   spec.email         = ["kalle@saits.se"]
 

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "faraday", "0.12.0"
-  spec.add_runtime_dependency "faraday_middleware", "~> 0.12"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "faraday", "0.12.0"
+  spec.add_runtime_dependency "faraday_middleware", "~> 0.12"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -5,7 +5,7 @@ require "faceit-ruby/client"
 
 Gem::Specification.new do |spec|
   spec.name          = "faceit-ruby"
-  spec.version       = "3.0.4"
+  spec.version       = "3.0.7"
   spec.authors       = ["Kalle Lundgren"]
   spec.email         = ["kalle@saits.se"]
 

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "faraday", "0.12.2"
-  spec.add_dependency "faraday_middleware", "~> 0.12"
+  spec.add_dependency "faraday_middleware", "~> 0.10"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -5,7 +5,7 @@ require "faceit-ruby/client"
 
 Gem::Specification.new do |spec|
   spec.name          = "faceit-ruby"
-  spec.version       = "3.0.1"
+  spec.version       = "3.0.4"
   spec.authors       = ["Kalle Lundgren"]
   spec.email         = ["kalle@saits.se"]
 

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "faceit-ruby"
-  spec.version       = "3.0.8"
+  spec.version       = "3.1.0"
   spec.authors       = ["Kalle Lundgren"]
   spec.email         = ["kalle@saits.se"]
 

--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "faceit-ruby"
-  spec.version       = "3.1.0"
+  spec.version       = "3.1.1"
   spec.authors       = ["Kalle Lundgren"]
   spec.email         = ["kalle@saits.se"]
 

--- a/lib/faceit-ruby/client.rb
+++ b/lib/faceit-ruby/client.rb
@@ -18,8 +18,6 @@ module Faceit
     def initialize(api_key: nil)
       if api_key.nil?
         raise "An APIKEY is required to create client"
-      elsif !!api_key
-        warn(%{WARNING: Apikey is required.})
       end
 
       headers = {

--- a/lib/faceit-ruby/client.rb
+++ b/lib/faceit-ruby/client.rb
@@ -1,5 +1,4 @@
 require "faraday"
-require "faraday_middleware"
 
 require "faceit-ruby/response"
 require "faceit-ruby/api_error"

--- a/lib/faceit-ruby/client.rb
+++ b/lib/faceit-ruby/client.rb
@@ -1,4 +1,5 @@
 require "faraday"
+require "faraday_middleware"
 
 require "faceit-ruby/response"
 require "faceit-ruby/api_error"

--- a/lib/faceit-ruby/version.rb
+++ b/lib/faceit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Faceit
-  VERSION = "3.0.2"
+  VERSION = "3.0.4"
 end

--- a/lib/faceit-ruby/version.rb
+++ b/lib/faceit-ruby/version.rb
@@ -1,3 +1,3 @@
 module Faceit
-  VERSION = "3.0.1"
+  VERSION = "3.0.2"
 end


### PR DESCRIPTION
It doesn't appear like this check is required, and in fact gives false positives:

Before change:

```
2.4.5 :014 > Faceit::Client.new(api_key: "<REDACTED>").get_player_by_nickname("kalleth")
WARNING: Apikey is required.
<snip results>
```

I think looking through your commit log this might have been a legacy from when the token and/or API key could both be required.

```
2.4.5 :015 > !!"string"
=> true
```