### PR TITLE
Remove relative path in gemfile

### DIFF
--- a/faceit-ruby.gemspec
+++ b/faceit-ruby.gemspec
@@ -1,7 +1,3 @@
-lib = File.expand_path("../lib", __FILE__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-
-
 Gem::Specification.new do |spec|
   spec.name          = "faceit-ruby"
 


### PR DESCRIPTION
This breaks on install on both CI and my local machine. 

```
[!] There was an error while loading `faceit-ruby.gemspec`: cannot load such file -- faraday
Does it try to require a relative path? That's been removed in Ruby 1.9. Bundler cannot continue.

#  from /home/rof/cache/bundler/ruby/2.5.0/bundler/gems/faceit-ruby-b3e279acd370/faceit-ruby.gemspec:3
#  -------------------------------------------
#  $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
>  require "faceit-ruby/client"
#  
#  -------------------------------------------
```